### PR TITLE
Create pipeline stage to generate zowe_licenses_full.zip

### DIFF
--- a/Jenkinsfile.license-scan
+++ b/Jenkinsfile.license-scan
@@ -120,5 +120,24 @@ node('zowe-dependency-scanning-rev2') {
       }
   )
 
+  pipeline.createStage(
+      name: "Collect Licenses for Full License Zip",
+      stage: {
+          dir("${DEPENDENCY_SCAN_HOME}/build") {
+            sh "mkdir zowe_licenses_full"
+
+            //Get the full notices, full dependency list, and current staging branch's bill of materials
+            sh "cp notice_reports/notices_aggregate.txt zowe_licenses_full/zowe_full_notices.txt"
+            sh "cp license_reports/markdown_dependency_report.md zowe_licenses_full/zowe_full_dependency_list.md"
+            sh "curl -o zowe_licenses_full/zowe_full_bill_of_materials.md https://raw.githubusercontent.com/zowe/docs-site/docs-staging/docs/appendix/bill-of-materials.md"
+
+            //Change directory so ZIP file will contain the same structure as before when created.
+            sh "cd zowe_licenses_full"
+            sh "zip -r zowe_licenses_full.zip ./*"
+
+            archiveArtifacts artifacts: "zowe_licenses_full.zip"
+          }
+      }
+  )
   pipeline.end()
 }


### PR DESCRIPTION
Adds a pipeline stage that gathers and zips the contents of the zowe_license_full Zip file that appears in Artifactory, using the same file names and directory structure as before.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>