### PR TITLE
Update to scan Zowe CLI v2

### DIFF
--- a/Jenkinsfile.license-scan
+++ b/Jenkinsfile.license-scan
@@ -29,7 +29,7 @@ node('zowe-dependency-scanning-rev-split') {
     )
   )
 
-  def ZOWE_BRANCH = "rc"
+  def ZOWE_BRANCH = "zowe-v2"
   def DEPENDENCY_SCAN_HOME = "/home/jenkins/dependency-scan"
   def PENDING_APPROVAL_REPORT_NAME = "dependency_approval_action_aggregates.json"
   def MARKDOWN_REPORT_NAME = "markdown_dependency_report.md"
@@ -40,7 +40,7 @@ node('zowe-dependency-scanning-rev-split') {
   def NOTICES_ZOS_FILE = "notices_zos.txt"
   def ARTIFACT_REPO= "libs-snapshot-local"
   def ARTIFACT_PATH= "org/zowe/licenses"
-  def VERSION = "1.26.0"
+  def VERSION = "2.0.0-alpha"
   def ARTIFACT_VERSION = "${VERSION}-SNAPSHOT"
   def AGG_ARTIFACT_NAME = "zowe_licenses_full-SNAPSHOT.zip"
   def CLI_ARTIFACT_NAME = "zowe_licenses_cli-SNAPSHOT.zip"


### PR DESCRIPTION
⚠️ Please do not merge into master branch. This should be created as a new branch `v2/main` to scan licenses for Zowe v2 components.