### PR TITLE
v2: Update ZE references to use new repo name zowe-explorer-vscode

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -74,7 +74,6 @@ jobs:
           - sample-iframe-app
           - sample-react-app
           - tn3270-ng2
-          - vscode-extension-for-zowe
           - vt-ng2
           - zlux-app-manager
           - zlux-app-server
@@ -95,6 +94,7 @@ jobs:
           - zowe-cli-ims-plugin
           - zowe-cli-mq-plugin
           - zowe-cli-scs-plugin
+          - zowe-explorer-vscode
           - zss-auth
 
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -88,7 +88,7 @@ jobs:
           - zlux-workflow
           - zosmf-auth
           - zowe-cli
-          - zowe-cli-cics-plugin
+          - cics-for-zowe-client
           - zowe-cli-db2-plugin
           - zowe-cli-ftp-plugin
           - zowe-cli-ims-plugin

--- a/licenses/dependency-scan/resources/repoRules.json
+++ b/licenses/dependency-scan/resources/repoRules.json
@@ -48,7 +48,9 @@
 			"allow_dynamic_versions": true
 		}
 	},
-	"vscode-extension-for-zowe": {
+	"zowe-cli": {
+	},
+	"zowe-explorer-vscode": {
 		"excludes": {
 			"paths": [
 				{
@@ -58,7 +60,5 @@
 				}
 			]
 		}
-	},
-	"zowe-cli": {
 	}
 }

--- a/licenses/dependency-scan/src/actions/base/InstallAction.ts
+++ b/licenses/dependency-scan/src/actions/base/InstallAction.ts
@@ -104,7 +104,7 @@ export class InstallAction implements IAction {
                 /// -- Alternatives to skip-integrity-check are dropping network-concurrency to 1 and/or setting a mutex on yarn install.
                 console.log("Issuing yarn install in " + absDir);
                 const installProcess = spawn("yarn", ["install",
-                    ((projectDir === "vscode-extension-for-zowe") ? "" : "--production"),
+                    ((projectDir === "zowe-explorer-vscode") ? "" : "--production"),
                     "--network-timeout", "300000", "--ignore-engines",
                     "--registry", "https://zowe.jfrog.io/zowe/api/npm/npm-release",
                     "--skip-integrity-check", "--network-concurrency", "5"], { cwd: absDir, env: process.env, shell: true });


### PR DESCRIPTION
Related to https://github.com/zowe/zowe-explorer-vscode/issues/1237