### PR TITLE
Fix V3 scans for client-side & generate separate VSCode notices bundle

### DIFF
--- a/.dockerfiles/ort.Dockerfile
+++ b/.dockerfiles/ort.Dockerfile
@@ -51,7 +51,7 @@ RUN rustup install stable && rustup default stable
 RUN cargo install cargo-license
 RUN cargo install get-license-helper
 
-ARG ORT_VERSION=15.1.0
+ARG ORT_VERSION=33.1.0
 
 RUN git clone https://github.com/oss-review-toolkit/ort
 WORKDIR /home/build/ort

--- a/.github/workflows/license-generation.yml
+++ b/.github/workflows/license-generation.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zowe-docker-snapshot.jfrog.io/ompzowe/zowecicd-license-base:test-timothy
+      image: zowe-docker-release.jfrog.io/ompzowe/zowecicd-license-base:latest
 
     steps:
       - name: Update variables if releasing

--- a/.github/workflows/license-generation.yml
+++ b/.github/workflows/license-generation.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zowe-docker-release.jfrog.io/ompzowe/zowecicd-license-base:latest
+      image: zowe-docker-snapshot.jfrog.io/ompzowe/zowecicd-license-base:test-timothy
 
     steps:
       - name: Update variables if releasing

--- a/.github/workflows/license-generation.yml
+++ b/.github/workflows/license-generation.yml
@@ -28,10 +28,10 @@ on:
         type: string
         required: false
         default: ''
-      zowe_sources_branch: 
+      zowe_sources_branch:
         description: The branch of zowe-install-packaging used to determine sources included in the scan
         required: true
-        default: 'v2.x/rc' 
+        default: 'v2.x/rc'
       dummy_build:
         description: Creates empty zip files, bypassing license scans. For test purposes only.
         required: false
@@ -52,26 +52,30 @@ on:
           - 'debug'
 
 env:
-  PUBLISH_RELEASE:  ${{ github.event.inputs.publish_release }}
+  PUBLISH_RELEASE: ${{ github.event.inputs.publish_release }}
   RELEASE_SUFFIX: ${{ github.event.inputs.release_suffix }}
-  REPLACE_EXISTING_RELEASE:  ${{ github.event.inputs.replace_release }} 
+  REPLACE_EXISTING_RELEASE: ${{ github.event.inputs.replace_release }}
   ZOWE_RELEASE_BRANCH: ${{ github.event.inputs.zowe_sources_branch }}
   PENDING_APPROVAL_REPORT_NAME: dependency_approval_action_aggregates.json
   DEPENDENCY_SCAN_HOME: licenses/dependency-scan
   MARKDOWN_REPORT_NAME: markdown_dependency_report.md
   MARKDOWN_CLI_REPORT: cli_dependency_report.md
+  MARKDOWN_VSCODE_REPORT: vscode_dependency_report.md
   MARKDOWN_ZOS_REPORT: zos_dependency_report.md
   NOTICES_AGGREGATE_FILE: notices_aggregate.txt
   NOTICES_CLI_FILE: notices_cli.txt
+  NOTICES_VSCODE_FILE: notices_vscode.txt
   NOTICES_ZOS_FILE: notices_zos.txt
   ARTIFACT_PATH: org/zowe/licenses
   ARTIFACT_PATH_SBOM: init_in_step_one
   VERSION: ${{ github.event.inputs.zowe_version }}
   AGG_ARTIFACT_NAME: zowe_licenses_full.zip
   CLI_ARTIFACT_NAME: zowe_licenses_cli.zip
+  VSCODE_ARTIFACT_NAME: zowe_licenses_vscode.zip
   ZOS_ARTIFACT_NAME: zowe_licenses_zos.zip
   AGG_SBOM_ARTIFACT_NAME: sbom_aggregate.spdx.yml
   CLI_SBOM_ARTIFACT_NAME: sbom_cli.spdx.yml
+  VSCODE_SBOM_ARTIFACT_NAME: sbom_vscode.spdx.yml
   ZOS_SBOM_ARTIFACT_NAME: sbom_zos.spdx.yml
   FILENAME_PATTERN: init_in_step_one
   ARTIFACT_REPO: init_in_step_one
@@ -84,13 +88,13 @@ jobs:
   create-licenses:
 
     runs-on: ubuntu-latest
-  
+
     container:
       image: zowe-docker-release.jfrog.io/ompzowe/zowecicd-license-base:latest
 
     steps:
       - name: Update variables if releasing
-        run: | 
+        run: |
           if [ "$PUBLISH_RELEASE" = true ]; then
               echo "ARTIFACT_REPO=libs-release-local" >> $GITHUB_ENV
               echo "ARTIFACT_VERSION=$VERSION" >> $GITHUB_ENV
@@ -102,44 +106,48 @@ jobs:
               echo "ARTIFACT_PATH_SBOM=org/zowe/${{ env.VERSION }}-SNAPSHOT/sbom" >> $GITHUB_ENV
               echo "FILENAME_PATTERN={filename}-${{ env.VERSION }}-SNAPSHOT{timestamp}{fileext}" >> $GITHUB_ENV
           fi
-    
+
       - name: Checkout current repo
         uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-        
+
       - name: '[Zowe Actions] Prepare workflow'
         uses: zowe-actions/shared-actions/prepare-workflow@main
-      
+
       - name: 'Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_ENV_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 
       - name: '[TEST-ONLY] Dummy scan step'
-        if: ${{ github.event.inputs.dummy_build == 'true' }} 
+        if: ${{ github.event.inputs.dummy_build == 'true' }}
         working-directory: ${{ env.DEPENDENCY_SCAN_HOME }}
-        run: | 
+        run: |
           mkdir -p zowe_licenses
           mkdir -p zowe_cli_licenses
+          mkdir -p zowe_vscode_licenses
           mkdir -p zowe_zos_licenses
           echo "HI" >> dummy.txt
           cp dummy.txt zowe_licenses
           cp dummy.txt zowe_cli_licenses
+          cp dummy.txt zowe_vscode_licenses
           cp dummy.txt zowe_zos_licenses
 
           zip -j ${{ env.AGG_ARTIFACT_NAME }} zowe_licenses/*
           zip -j ${{ env.CLI_ARTIFACT_NAME }} zowe_cli_licenses/*
+          zip -j ${{ env.VSCODE_ARTIFACT_NAME }} zowe_vscode_licenses/*
           zip -j ${{ env.ZOS_ARTIFACT_NAME }} zowe_zos_licenses/*
           echo "" > ${{ env.AGG_SBOM_ARTIFACT_NAME }}
-          echo "" > ${{ env.ZOS_SBOM_ARTIFACT_NAME }}
           echo "" > ${{ env.CLI_SBOM_ARTIFACT_NAME }}
+          echo "" > ${{ env.VSCODE_SBOM_ARTIFACT_NAME }}
+          echo "" > ${{ env.ZOS_SBOM_ARTIFACT_NAME }}
 
 
       - name: Scan Licenses on Branch ${{ env.ZOWE_RELEASE_BRANCH }}
-        if: ${{ github.event.inputs.dummy_build == 'false' }} 
+        if: ${{ github.event.inputs.dummy_build == 'false' }}
         env:
           APP_NOTICES_SCAN: true
           APP_LICENSE_SCAN: true
@@ -147,23 +155,25 @@ jobs:
         working-directory: ${{ env.DEPENDENCY_SCAN_HOME }}
         run: |
           # Rustup is set to default in the container, but it's not picked up in this run block
-          rustup default stable  
+          rustup default stable
           yarn install && yarn build
           node lib/index.js
           cd build
-          zip -r logs.zip logs/ 
+          zip -r logs.zip logs/
           zip -r license_reports.zip license_reports/
           zip -r notice_reports.zip notice_reports/
           cd ..
           mkdir -p zowe_licenses
           mkdir -p zowe_cli_licenses
+          mkdir -p zowe_vscode_licenses
           mkdir -p zowe_zos_licenses
           cp ../resources/* zowe_licenses/
           cp ../resources/* zowe_cli_licenses/
+          cp ../resources/* zowe_vscode_licenses/
           cp ../resources/* zowe_zos_licenses/
 
           zip -r logs.zip build/logs/*
-     
+
           # Aggregate
           cp build/notice_reports/${{ env.NOTICES_AGGREGATE_FILE }} zowe_licenses/zowe_full_notices.txt
           cp build/license_reports/${{ env.MARKDOWN_REPORT_NAME }} zowe_licenses/zowe_full_dependency_list.md
@@ -173,6 +183,12 @@ jobs:
           cp build/notice_reports/${{ env.NOTICES_CLI_FILE }} zowe_cli_licenses/zowe_cli_notices.txt
           cp build/license_reports/${{ env.MARKDOWN_CLI_REPORT }} zowe_cli_licenses/zowe_cli_dependency_list.md
           zip -j ${{ env.CLI_ARTIFACT_NAME }} zowe_cli_licenses/*
+
+          # VSCode
+          cp build/notice_reports/${{ env.NOTICES_VSCODE_FILE }} zowe_vscode_licenses/zowe_vscode_notices.txt
+          cp build/license_reports/${{ env.MARKDOWN_VSCODE_REPORT }} zowe_vscode_licenses/zowe_vscode_dependency_list.md
+          zip -j ${{ env.VSCODE_ARTIFACT_NAME }} zowe_vscode_licenses/*
+
           # z/OS
           cp build/notice_reports/${{ env.NOTICES_ZOS_FILE }} zowe_zos_licenses/zowe_zos_notices.txt
           cp build/license_reports/${{ env.MARKDOWN_ZOS_REPORT }} zowe_zos_licenses/zowe_zos_dependency_list.md
@@ -181,6 +197,7 @@ jobs:
           # SBOMs
           cp build/sbom_reports/${{ env.AGG_SBOM_ARTIFACT_NAME }} ${{ env.AGG_SBOM_ARTIFACT_NAME }}
           cp build/sbom_reports/${{ env.CLI_SBOM_ARTIFACT_NAME }} ${{ env.CLI_SBOM_ARTIFACT_NAME }}
+          cp build/sbom_reports/${{ env.VSCODE_SBOM_ARTIFACT_NAME }} ${{ env.VSCODE_SBOM_ARTIFACT_NAME }}
           cp build/sbom_reports/${{ env.ZOS_SBOM_ARTIFACT_NAME }} ${{ env.ZOS_SBOM_ARTIFACT_NAME }}
 
 
@@ -203,6 +220,11 @@ jobs:
             --user ${{ secrets.ZOWE_JFROG_ELEVATED_USER }} \
             --password ${{secrets.ZOWE_JFROG_ELEVATED_KEY }} \
             --url https://zowe.jfrog.io/artifactory \
+            ${{ env.ARTIFACT_REPO }}/${{ env.ARTIFACT_PATH }}/${{ env.ARTIFACT_VERSION }}/${{ env.VSCODE_ARTIFACT_NAME }}
+          jfrog rt del\
+            --user ${{ secrets.ZOWE_JFROG_ELEVATED_USER }} \
+            --password ${{secrets.ZOWE_JFROG_ELEVATED_KEY }} \
+            --url https://zowe.jfrog.io/artifactory \
             ${{ env.ARTIFACT_REPO }}/${{ env.ARTIFACT_PATH }}/${{ env.ARTIFACT_VERSION }}/${{ env.ZOS_ARTIFACT_NAME }}
           jfrog rt del\
             --user ${{ secrets.ZOWE_JFROG_ELEVATED_USER }} \
@@ -214,6 +236,11 @@ jobs:
             --password ${{secrets.ZOWE_JFROG_ELEVATED_KEY }} \
             --url https://zowe.jfrog.io/artifactory \
             ${{ env.ARTIFACT_REPO }}/${{ env.ARTIFACT_PATH }}/${{ env.ARTIFACT_VERSION }}/${{ env.CLI_SBOM_ARTIFACT_NAME }}
+          jfrog rt del\
+            --user ${{ secrets.ZOWE_JFROG_ELEVATED_USER }} \
+            --password ${{secrets.ZOWE_JFROG_ELEVATED_KEY }} \
+            --url https://zowe.jfrog.io/artifactory \
+            ${{ env.ARTIFACT_REPO }}/${{ env.ARTIFACT_PATH }}/${{ env.ARTIFACT_VERSION }}/${{ env.VSCODE_SBOM_ARTIFACT_NAME }}
           jfrog rt del\
             --user ${{ secrets.ZOWE_JFROG_ELEVATED_USER }} \
             --password ${{secrets.ZOWE_JFROG_ELEVATED_KEY }} \
@@ -237,7 +264,8 @@ jobs:
           sigstore-sign-artifacts: true
           artifacts: |
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.AGG_ARTIFACT_NAME }}
-            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_ARTIFACT_NAME }}  
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_ARTIFACT_NAME }}
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.VSCODE_ARTIFACT_NAME }}
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.ZOS_ARTIFACT_NAME }}
 
       - name: Publish to Artifactory
@@ -252,9 +280,10 @@ jobs:
           artifacts: |
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.AGG_SBOM_ARTIFACT_NAME }}
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_SBOM_ARTIFACT_NAME }}
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.VSCODE_SBOM_ARTIFACT_NAME }}
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.ZOS_SBOM_ARTIFACT_NAME }}
 
-      - name: Archive Aggregates  
+      - name: Archive Aggregates
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
@@ -262,13 +291,17 @@ jobs:
             ${{ env.DEPENDENCY_SCAN_HOME }}/logs.zip
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.AGG_ARTIFACT_NAME }}
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.AGG_ARTIFACT_NAME }}.bundle
-            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_ARTIFACT_NAME }}  
-            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_ARTIFACT_NAME }}.bundle    
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_ARTIFACT_NAME }}
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_ARTIFACT_NAME }}.bundle
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.VSCODE_ARTIFACT_NAME }}
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.VSCODE_ARTIFACT_NAME }}.bundle
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.ZOS_ARTIFACT_NAME }}
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.ZOS_ARTIFACT_NAME }}.bundle
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.AGG_SBOM_ARTIFACT_NAME }}
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.AGG_SBOM_ARTIFACT_NAME }}.bundle
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_SBOM_ARTIFACT_NAME }}
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.CLI_SBOM_ARTIFACT_NAME }}.bundle
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.VSCODE_SBOM_ARTIFACT_NAME }}
+            ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.VSCODE_SBOM_ARTIFACT_NAME }}.bundle
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.ZOS_SBOM_ARTIFACT_NAME }}
             ${{ env.DEPENDENCY_SCAN_HOME }}/${{ env.ZOS_SBOM_ARTIFACT_NAME }}.bundle

--- a/.github/workflows/license-generation.yml
+++ b/.github/workflows/license-generation.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           # Rustup is set to default in the container, but it's not picked up in this run block
           rustup default stable
+          npm install -g pnpm@8
           yarn install && yarn build
           node lib/index.js
           cd build

--- a/licenses/dependency-scan/resources/repoRules.json
+++ b/licenses/dependency-scan/resources/repoRules.json
@@ -57,6 +57,11 @@
 					"pattern": "**/samples/**",
 					"reason": "EXAMPLE_OF",
 					"comment": "Sample APIs"
+				},
+				{
+					"pattern": "**/zedc/**",
+					"reason": "TEST_DEPENDENCY_OF",
+					"comment": "Development CLI"
 				}
 			]
 		}

--- a/licenses/dependency-scan/resources/repoRules.json
+++ b/licenses/dependency-scan/resources/repoRules.json
@@ -60,7 +60,7 @@
 				},
 				{
 					"pattern": "**/zedc/**",
-					"reason": "TEST_DEPENDENCY_OF",
+					"reason": "TEST_TOOL_OF",
 					"comment": "Development CLI"
 				}
 			]

--- a/licenses/dependency-scan/src/actions/base/InstallAction.ts
+++ b/licenses/dependency-scan/src/actions/base/InstallAction.ts
@@ -88,15 +88,15 @@ export class InstallAction implements IAction {
                 //default npm install prod
                 let installCmd = "npm";
                 let installArgs = ["install", "--omit=dev", ...registry];
-                
+
                 if (Utilities.hasPnpmLockFile(`${absDir}`)) {
                     installCmd = "pnpm";
-                    installArgs = ["install", "--frozen-lockfile", "--prod", ...registry]
+                    installArgs = ["install", "--frozen-lockfile", "--prod", "--ignore-scripts", ...registry]
                 } else if (Utilities.hasNpmLockfile(`${absDir}`)) {
-                    installArgs = ["ci", "--omit=dev", ...registry]
+                    installArgs = ["ci", "--omit=dev", "--ignore-scripts", ...registry]
                 } else if (Utilities.hasYarnLockfile(`${absDir}`)) {
                     installCmd = "yarn";
-                    installArgs = ["install", "--production", "--frozen-lockfile", "--ignore-engines", ...registry]
+                    installArgs = ["install", "--production", "--frozen-lockfile", "--ignore-engines", "--ignore-scripts", ...registry]
                 }
 
                 if (fs.existsSync(path.join(absDir, "node_modules"))) {

--- a/licenses/dependency-scan/src/actions/ort/OrtReportAction.ts
+++ b/licenses/dependency-scan/src/actions/ort/OrtReportAction.ts
@@ -35,6 +35,7 @@ export class OrtReportAction implements IAction {
 
     private readonly AGG_REPORT_MARKDOWN_FILE = path.resolve(Constants.LICENSE_REPORTS_DIR, "markdown_dependency_report.md");
     private readonly CLI_REPORT_MARKDOWN_FILE = path.resolve(Constants.LICENSE_REPORTS_DIR, "cli_dependency_report.md")
+    private readonly VSCODE_REPORT_MARKDOWN_FILE = path.resolve(Constants.LICENSE_REPORTS_DIR, "vscode_dependency_report.md")
     private readonly ZOS_REPORT_MARKDOWN_FILE = path.resolve(Constants.LICENSE_REPORTS_DIR, "zos_dependency_report.md")
 
     private reportQueue: async.AsyncQueue<any> = async.queue(this.reportProject.bind(this), Constants.PARALLEL_REPORT_COUNT);
@@ -91,6 +92,7 @@ export class OrtReportAction implements IAction {
             const sourceDependencies: ZoweManifestSourceDependency[] = this.zoweManifest.sourceDependencies;
             const aggregateNoticesFile = path.join(Constants.NOTICE_REPORTS_DIR, "notices_aggregate.txt");
             const cliNoticesFile = path.join(Constants.NOTICE_REPORTS_DIR, "notices_cli.txt");
+            const vscodeNoticesFile = path.join(Constants.NOTICE_REPORTS_DIR, "notices_vscode.txt");
             const zosNoticesFile = path.join(Constants.NOTICE_REPORTS_DIR, "notices_zos.txt");
 
             (sourceDependencies).forEach((dependency: ZoweManifestSourceDependency) => {
@@ -106,6 +108,8 @@ export class OrtReportAction implements IAction {
                         fs.appendFileSync(aggregateNoticesFile, fs.readFileSync(noticesTxtFile).toString() + "\n");
                         if (noticeInstance.destinations.join(",").includes("CLI")) {
                             fs.appendFileSync(cliNoticesFile, fs.readFileSync(noticesTxtFile).toString() + "\n");
+                        } else if (noticeInstance.destinations.join(",").includes("Visual Studio Code")) {
+                            fs.appendFileSync(vscodeNoticesFile, fs.readFileSync(noticesTxtFile).toString() + "\n");
                         } else {
                             fs.appendFileSync(zosNoticesFile, fs.readFileSync(noticesTxtFile).toString() + "\n");
                         }
@@ -125,9 +129,11 @@ export class OrtReportAction implements IAction {
 
             const aggregateReportFile = fs.createWriteStream(this.AGG_REPORT_MARKDOWN_FILE, { flags: "a" });
             const cliReportFile = fs.createWriteStream(this.CLI_REPORT_MARKDOWN_FILE)
+            const vscodeReportFile = fs.createWriteStream(this.VSCODE_REPORT_MARKDOWN_FILE)
             const zosReportFile = fs.createWriteStream(this.ZOS_REPORT_MARKDOWN_FILE)
             aggregateReportFile.write("# Zowe Third Party Library Usage\n\n");
             cliReportFile.write("# Zowe CLI Third Party Library Usage\n\n");
+            vscodeReportFile.write("# Zowe Explorer for VS Code Third Party Library Usage\n\n");
             zosReportFile.write("# Zowe z/OS Third Party Library Usage\n\n");
             (sourceDependencies).forEach((dependency) => {
                 aggregateReportFile.write("* [" + dependency.componentGroup + "](#" + dependency.componentGroup.replace(/\s/g, "-").toLowerCase()
@@ -136,6 +142,9 @@ export class OrtReportAction implements IAction {
                     if (dependency.entries[0].destinations.join(",").includes("CLI")) {
                         cliReportFile.write("* [" + dependency.componentGroup + "](#" + dependency.componentGroup.replace(/\s/g, "-").toLowerCase()
                             + "-dependency-attributions)" + "\n");
+                    } else if (dependency.entries[0].destinations.join(",").includes("Visual Studio Code")) {
+                        vscodeReportFile.write("* [" + dependency.componentGroup + "](#" + dependency.componentGroup.replace(/\s/g, "-").toLowerCase()
+                            + "-dependency-attributions)" + "\n");
                     } else {
                         zosReportFile.write("* [" + dependency.componentGroup + "](#" + dependency.componentGroup.replace(/\s/g, "-").toLowerCase()
                             + "-dependency-attributions)" + "\n");
@@ -143,8 +152,9 @@ export class OrtReportAction implements IAction {
                 }
             });
             aggregateReportFile.write("\n");
-            zosReportFile.write("\n");
             cliReportFile.write("\n");
+            vscodeReportFile.write("\n");
+            zosReportFile.write("\n");
 
             (sourceDependencies).forEach((dependency: ZoweManifestSourceDependency) => {
                 const reports: ReportInfo[] = (dependency.entries.map((depEntry): ReportInfo => {
@@ -157,10 +167,12 @@ export class OrtReportAction implements IAction {
 
                 let totalDepCt = 0;
                 let cliDepCt = 0;
+                let vscodeDepCt = 0;
                 let zosDepCt = 0;
                 let missingReport: boolean = false;
                 let fullReportString = "";
                 let cliReportString = fullReportString
+                let vscodeReportString = fullReportString
                 let zosReportString = fullReportString
                 reports.forEach((reportInstance: ReportInfo) => {
                     try {
@@ -176,6 +188,10 @@ export class OrtReportAction implements IAction {
                                 cliDepCt += reportDepCt
                                 cliReportString += `### ${dependency.componentGroup} Dependency Attributions\n`
                                 cliReportString += lines.join("\n");
+                            } else if (reportInstance.destinations.join(",").includes("Visual Studio Code")) {
+                                vscodeDepCt += reportDepCt
+                                vscodeReportString += `### ${dependency.componentGroup} Dependency Attributions\n`
+                                vscodeReportString += lines.join("\n");
                             } else {
                                 zosDepCt += reportDepCt
                                 zosReportString += `### ${dependency.componentGroup} Dependency Attributions\n`
@@ -195,6 +211,10 @@ export class OrtReportAction implements IAction {
                 if (cliDepCt > 0) {
                     cliReportFile.write(cliReportString);
                     cliReportFile.write("\n\n")
+                }
+                if (vscodeDepCt > 0) {
+                    vscodeReportFile.write(vscodeReportString);
+                    vscodeReportFile.write("\n\n")
                 }
                 if (zosDepCt > 0) {
                     zosReportFile.write(zosReportString);

--- a/licenses/dependency-scan/src/actions/ort/OrtSbomAction.ts
+++ b/licenses/dependency-scan/src/actions/ort/OrtSbomAction.ts
@@ -34,6 +34,7 @@ export class OrtSbomAction implements IAction {
 
     private readonly SBOM_ZOS_REPORT = path.resolve(Constants.SBOM_REPORTS_DIR, "sbom_zos.spdx.yml");
     private readonly SBOM_CLI_REPORT = path.resolve(Constants.SBOM_REPORTS_DIR, "sbom_cli.spdx.yml");
+    private readonly SBOM_VSCODE_REPORT = path.resolve(Constants.SBOM_REPORTS_DIR, "sbom_vscode.spdx.yml");
     private readonly SBOM_AGG_REPORT = path.resolve(Constants.SBOM_REPORTS_DIR, "sbom_aggregate.spdx.yml");
     private sbomQueue: async.AsyncQueue<any> = async.queue(this.reportSboms.bind(this), Constants.PARALLEL_NOTICE_REPORT_COUNT);
 
@@ -85,6 +86,8 @@ export class OrtSbomAction implements IAction {
                         fs.appendFileSync(this.SBOM_AGG_REPORT, fs.readFileSync(sbomFile).toString());
                         if (sbomReport.destinations.join(",").includes("CLI")) {
                             fs.appendFileSync(this.SBOM_CLI_REPORT, fs.readFileSync(sbomFile).toString());
+                        } else if (sbomReport.destinations.join(",").includes("Visual Studio Code")) {
+                            fs.appendFileSync(this.SBOM_VSCODE_REPORT, fs.readFileSync(sbomFile).toString());
                         } else {
                             fs.appendFileSync(this.SBOM_ZOS_REPORT, fs.readFileSync(sbomFile).toString());
                         }

--- a/licenses/dependency-scan/yarn.lock
+++ b/licenses/dependency-scan/yarn.lock
@@ -35,7 +35,7 @@
   resolved "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz"
   integrity sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==
 
-"@octokit/core@^5.0.0", "@octokit/core@>=5":
+"@octokit/core@^5.0.0":
   version "5.1.0"
   resolved "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz"
   integrity sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==
@@ -290,15 +290,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 commander@^2.12.1:
   version "2.20.3"
@@ -310,15 +310,6 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-cross-spawn@^7.0.0:
-  version "7.0.3"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
 cross-spawn@6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz"
@@ -329,6 +320,15 @@ cross-spawn@6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.0:
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -487,10 +487,10 @@ lodash@^4.17.14, lodash@^4.17.21:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-"lru-cache@^9.1.1 || ^10.0.0":
-  version "10.0.1"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz"
-  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 minimatch@^3.0.4:
   version "3.1.2"
@@ -556,11 +556,11 @@ path-parse@^1.0.6:
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-scurry@^1.10.1:
-  version "1.10.1"
-  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz"
-  integrity sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
   dependencies:
-    lru-cache "^9.1.1 || ^10.0.0"
+    lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 reflect-metadata@^0.1.13:
@@ -717,7 +717,7 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-"typescript@>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev", "typescript@>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev", typescript@5.2.2:
+typescript@5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==


### PR DESCRIPTION
Re-creating #146 

* Moved the notices for `zowe-explorer-vscode` into a separate zip artifact. Previously the VSCode notices were being included with the zos components.
* Added `--ignore-scripts` flag to npm/yarn/pnpm install commands. Since the `--prod` flag was added in https://github.com/zowe/zowe-dependency-scan-pipeline/pull/145, the `prepare` script fails for some repos if it requires a dev dep (e.g. `husky`).
* Added step to install pnpm in workflow because it was missing from PATH. Not sure why the install script added to Dockerfile in https://github.com/zowe/zowe-dependency-scan-pipeline/pull/145 didn't work.
* Updated version of ORT in Dockerfile and published a snapshot with `test-timothy` tag. V15 had several errors causing it to fail parsing [Cargo](https://github.com/oss-review-toolkit/ort/issues/8480) (CLI daemon) and [PNPM](https://github.com/oss-review-toolkit/ort/issues/8987) (ZE) projects that were fixed by upgrading.

@awharn @zFernand0 @traeok Please review the [CLI](https://zowe.jfrog.io/ui/repos/tree/General/libs-snapshot-local/org/zowe/licenses/3.0.0-SNAPSHOT/zowe_licenses_cli-3.0.0-SNAPSHOT-20240927023104.zip?clearFilter=true) and [VSCode](https://zowe.jfrog.io/ui/repos/tree/General/libs-snapshot-local/org/zowe/licenses/3.0.0-SNAPSHOT/zowe_licenses_vscode-3.0.0-SNAPSHOT-20240927164322.zip?clearFilter=true) artifacts generated by the license workflow.